### PR TITLE
Regression Models Notation

### DIFF
--- a/7_REGMODS/Regression Models Course Notes HTML.Rmd
+++ b/7_REGMODS/Regression Models Course Notes HTML.Rmd
@@ -133,7 +133,7 @@ g
 
 
 ### Derivation for Least Squares = Empirical Mean (Finding the Minimum)
-* Let $X_i = **regressor**/**predictor**, and $Y_i =$ **outcome**/**result** so we want to minimize the the squares: $$\sum_{i=1}^n (Y_i - \mu)^2$$
+* Let $X_i =$ **regressor**/**predictor**, and $Y_i =$ **outcome**/**result** so we want to minimize the the squares: $$\sum_{i=1}^n (Y_i - \mu)^2$$
 * Proof is as follows $$
 \begin{aligned}
 \sum_{i=1}^n (Y_i - \mu)^2 & = \sum_{i=1}^n (Y_i - \bar Y + \bar Y - \mu)^2 \Leftarrow \mbox{added}  \pm \bar Y \mbox{which is adding 0 to the original equation}\\

--- a/7_REGMODS/Regression Models Course Notes.Rmd
+++ b/7_REGMODS/Regression Models Course Notes.Rmd
@@ -131,7 +131,7 @@ g
 $\pagebreak$
 
 ### Derivation for Least Squares = Empirical Mean (Finding the Minimum)
-* Let $X_i = **regressor**/**predictor**, and $Y_i =$ **outcome**/**result** so we want to minimize the the squares: $$\sum_{i=1}^n (Y_i - \mu)^2$$
+* Let $X_i =$ **regressor**/**predictor**, and $Y_i =$ **outcome**/**result** so we want to minimize the the squares: $$\sum_{i=1}^n (Y_i - \mu)^2$$
 * Proof is as follows $$
 \begin{aligned}
 \sum_{i=1}^n (Y_i - \mu)^2 & = \sum_{i=1}^n (Y_i - \bar Y + \bar Y - \mu)^2 \Leftarrow \mbox{added}  \pm \bar Y \mbox{which is adding 0 to the original equation}\\


### PR DESCRIPTION
Under "Derivation for Least Squares" the X_i notation wasn't rendering correctly because of incomplete notation.
